### PR TITLE
Ensure that gulp runs when postcss.config.js changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ task gulp(type: NpmTask) {
 	inputs.dir("src/main/css")
 	inputs.dir("src/main/img")
 	inputs.dir("src/main/js")
+	inputs.file("postcss.config.js")
 	outputs.dir(generatedAssets)
 	args = ["run", "build", "--output=${generatedAssets}"]
 }


### PR DESCRIPTION
`postcss-config.js` needs to be an input of the `gulp` task to ensure that it runs when a change is made to postcss's configuration.