### PR TITLE
Retain quotes on relative URLs in CSS

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -4,7 +4,9 @@ module.exports = {
   plugins: {
     "postcss-import": {},
     cssnano: {
-      preset: "default",
+      preset: ["default", {
+        normalizeUrl: false,
+      }]
     },
     "autoprefixer": {}
   },


### PR DESCRIPTION
cssnano's normalizeUrl removes quotes from relative URLs, underminining the fix for #11 that was made in 8aab4d78d.

There's no configuration option that I can see on normalizeUrl to disable the removal of quotes, so this PR disables normalizeUrl entirely.