### PR TITLE
Support XML code include

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -447,6 +447,10 @@ The following languages are supported by convention based imports:
 | Groovy
 | `{docs-groovy}`
 | `.grovy`
+|
+| XML
+| `{docs-xml}`
+| `.xml`
 |===
 
 If more than one language file is found then tabs will automatically be created to allow the user to see all the examples.

--- a/src/main/java/io/spring/asciidoctor/backend/language/Language.java
+++ b/src/main/java/io/spring/asciidoctor/backend/language/Language.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.asciidoctor.ast.ContentNode;
  * Languages supported by the backend.
  *
  * @author Phillip Webb
+ * @author Sebastien Deleuze
  */
 public enum Language {
 
@@ -38,7 +39,12 @@ public enum Language {
 	/**
 	 * Groovy.
 	 */
-	GROOVY("Groovy", "docs-groovy", "groovy", true, "");
+	GROOVY("Groovy", "docs-groovy", "groovy", true, ""),
+
+	/**
+	 * XML.
+	 */
+	XML("XML", "docs-xml", "xml", false, "");
 
 	private final String title;
 

--- a/src/test/java/io/spring/asciidoctor/backend/includecode/IncludeCodeIncludeProcessorTests.java
+++ b/src/test/java/io/spring/asciidoctor/backend/includecode/IncludeCodeIncludeProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * Tests for {@link IncludeCodeIncludeProcessor}.
  *
  * @author Phillip Webb
+ * @author Sebastien Deleuze
  */
 @ExtendWith(AsciidoctorExtension.class)
 class IncludeCodeIncludeProcessorTests {
@@ -46,6 +47,11 @@ class IncludeCodeIncludeProcessorTests {
 
 	@Test
 	void includeJavaAndKotlin(ConvertedHtml html, ExpectedHtml expected) {
+		assertThat(html.getElementByClass("sectionbody")).satisfies(expected.whenIgnoringTrailingWhitespace());
+	}
+
+	@Test
+	void includeJavaKotlinAndXml(ConvertedHtml html, ExpectedHtml expected) {
 		assertThat(html.getElementByClass("sectionbody")).satisfies(expected.whenIgnoringTrailingWhitespace());
 	}
 

--- a/src/test/resources/io/spring/asciidoctor/backend/includecode/IncludeCodeIncludeProcessorTests_includeJavaKotlinAndXml.adoc
+++ b/src/test/resources/io/spring/asciidoctor/backend/includecode/IncludeCodeIncludeProcessorTests_includeJavaKotlinAndXml.adoc
@@ -1,0 +1,9 @@
+= Test Document
+:docs-java: {docdir}/javacode
+:docs-kotlin: {docdir}/kotlincode
+:docs-xml: {docdir}/xmlcode
+
+[[some.convention-based-anchor]]
+== Some Convention Based Anchor
+
+include::code:SomeCode[]

--- a/src/test/resources/io/spring/asciidoctor/backend/includecode/IncludeCodeIncludeProcessorTests_includeJavaKotlinAndXml/javacode/some/conventionbasedanchor/SomeCode._java
+++ b/src/test/resources/io/spring/asciidoctor/backend/includecode/IncludeCodeIncludeProcessorTests_includeJavaKotlinAndXml/javacode/some/conventionbasedanchor/SomeCode._java
@@ -1,0 +1,1 @@
+somejava

--- a/src/test/resources/io/spring/asciidoctor/backend/includecode/IncludeCodeIncludeProcessorTests_includeJavaKotlinAndXml/kotlincode/some/conventionbasedanchor/SomeCode._kt
+++ b/src/test/resources/io/spring/asciidoctor/backend/includecode/IncludeCodeIncludeProcessorTests_includeJavaKotlinAndXml/kotlincode/some/conventionbasedanchor/SomeCode._kt
@@ -1,0 +1,1 @@
+somekotlin

--- a/src/test/resources/io/spring/asciidoctor/backend/includecode/IncludeCodeIncludeProcessorTests_includeJavaKotlinAndXml/xmlCode/some/conventionbasedanchor/SomeCode._xml
+++ b/src/test/resources/io/spring/asciidoctor/backend/includecode/IncludeCodeIncludeProcessorTests_includeJavaKotlinAndXml/xmlCode/some/conventionbasedanchor/SomeCode._xml
@@ -1,0 +1,1 @@
+somexml

--- a/src/test/resources/io/spring/asciidoctor/backend/includecode/IncludeCodeIncludeProcessorTests_includeJavaKotlinAndXml_expected.html
+++ b/src/test/resources/io/spring/asciidoctor/backend/includecode/IncludeCodeIncludeProcessorTests_includeJavaKotlinAndXml_expected.html
@@ -1,0 +1,26 @@
+<div class="listingblock primary">
+ <div class="title">
+  Java
+ </div>
+ <div class="content">
+  <pre class="highlight"><code class="language-java" data-lang="java">somejava
+</code></pre>
+ </div>
+</div>
+<div class="listingblock secondary">
+ <div class="title">
+  Kotlin
+ </div>
+ <div class="content">
+  <pre class="highlight"><code class="language-kotlin" data-lang="kotlin">somekotlin
+</code></pre>
+ </div>
+</div>
+<div class="listingblock secondary">
+ <div class="title">
+  XML
+ </div>
+ <div class="content">
+  <pre class="highlight"><code class="language-xml" data-lang="xml">somexml</code></pre>
+ </div>
+</div>


### PR DESCRIPTION
The use case is for configuration code samples where JavaConfig and XML variants are provided in different tabs, see related https://github.com/spring-projects/spring-framework/issues/22171 issue. Other projects may want to leverage that as well as discussed with @rwinch.